### PR TITLE
Fix missing include for std::strcmp

### DIFF
--- a/sources/MaterialDesignIcons.cpp
+++ b/sources/MaterialDesignIcons.cpp
@@ -7,6 +7,7 @@
 #include <QPainter>
 
 #include <mutex>
+#include <cstring>
 
 namespace detail { namespace
 {


### PR DESCRIPTION
Trivial fix for std::strcmp which is defined in cstring header.

Signed-off-by: Francis Giraldeau <francis.giraldeau@nrc-cnrc.gc.ca>